### PR TITLE
centering content for wider screens

### DIFF
--- a/src/app/App.css
+++ b/src/app/App.css
@@ -15,10 +15,6 @@
   column-gap: 50px;
   padding: 20px;
   margin-top: max(60px, 10vh);
-  width: 100%;
-  max-width: 1280px;
-  margin-left: auto;
-  margin-right: auto;
 }
 
 .app>main {
@@ -34,6 +30,15 @@
   min-width: fit-content;
   overflow-y: auto;
   margin-top: 10px;
+}
+
+@media screen and (min-width: 1280px) {
+  .app {
+    width: 100%;
+    max-width: 1280px;
+    margin-left: auto;
+    margin-right: auto;
+  }
 }
 
 @media only screen and (max-width: 1200px) {

--- a/src/app/App.css
+++ b/src/app/App.css
@@ -15,16 +15,20 @@
   column-gap: 50px;
   padding: 20px;
   margin-top: max(60px, 10vh);
+  width: 100%;
+  max-width: 1280px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
-.app > main {
+.app>main {
   /* flex: 7 1 0; */
   flex: 7;
   min-width: 0;
   padding-top: 10px;
 }
 
-.app > aside {
+.app>aside {
   /* flex: 3 1 0; */
   flex: 3;
   min-width: fit-content;
@@ -48,11 +52,11 @@
     margin: 20px;
   }
 
-  .app > main {
+  .app>main {
     margin-top: max(60px, 10vh);
   }
 
-  .app > aside {
+  .app>aside {
     display: none;
   }
 }
@@ -64,7 +68,7 @@
     margin: 20px;
   }
 
-  .app > main {
+  .app>main {
     margin-top: max(60px, 10vh);
   }
 


### PR DESCRIPTION
I noticed on wider screens the content gets divided into two with a gap between
![Screenshot 2024-11-19 161857](https://github.com/user-attachments/assets/5da07509-9145-4e14-a4e5-e5b01cf67f57)

I added some CSS to center the content on wider screens
![Screenshot 2024-11-19 163458](https://github.com/user-attachments/assets/c32447d1-4065-4965-9f03-b1170b00ee9c)
