### PR TITLE
Add image URL validation to Post component

### DIFF
--- a/src/features/Post/Post.jsx
+++ b/src/features/Post/Post.jsx
@@ -27,6 +27,11 @@ export const Post = ({ post }) => {
   const handleToggleComments = () => {
     dispatch(toggleComments(post.id));
   }
+
+  const isImageUrl = (url) => {
+    return /\.(jpeg|jpg|gif|png)$/.test(url);
+  }
+
   return (
     <div className='post'>
       <div className='post-header'>
@@ -73,14 +78,14 @@ export const Post = ({ post }) => {
             <div className='ellipsis-indicator'>
             </div>}
         </p>
-        <div className='post-image-container'>
+        {isImageUrl(post.url) && <div className='post-image-container'>
           <img
             src={post.url}
             alt=""
             loading='lazy'
             className="post-image"
           />
-        </div>
+        </div>}
       </div>
       <div className='post-footer'>
         <span


### PR DESCRIPTION
Added a condition to check if a post's url ends with an image file format, doesn't render an empty image container if no image is found.

*There's a better way to handle this since some links (like news articles) have an image attached in the api somewhere, but i'd have to look into it and implement a more robust fix